### PR TITLE
Fix: add explicit resources for employee service to resolve deployment failure...

### DIFF
--- a/config-as-code/helm/charts/frontend/employee/values.yaml
+++ b/config-as-code/helm/charts/frontend/employee/values.yaml
@@ -38,3 +38,8 @@ extraVolumeMounts: |
     subPath: sub_filter.conf
 
 namespace: egov    
+resources:
+  requests:
+    memory: "256Mi"
+  limits:
+    memory: "512Mi"


### PR DESCRIPTION
## Issue
Employee service deployment was failing with:
"cannot unmarshal string into Go struct field resources"

## Root Cause
- resources were inherited from common chart as string (tpl-based)
- employee (frontend) service does not support this format

## Fix
- Added explicit resources in:
  config-as-code/helm/charts/frontend/employee/values.yaml

resources:
  requests:
    memory: "256Mi"
  limits:
    memory: "512Mi"

## Impact
- Fixes employee deployment issue
- No changes to other services
- Safe and minimal fix

## Testing
- Verified deployment works successfully